### PR TITLE
Dynamic prompt support

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -58,6 +58,7 @@ const configuration: UnixornConfiguration = {
 };
 
 const App = () => {
+  const [config, setConfig] = React.useState<UnixornConfiguration>(defaultConfiguration);
   return (
     <div className="app">
       <h1>Unixorn</h1>
@@ -67,15 +68,17 @@ const App = () => {
       <div className="example">
         <p>You can use Unixorn out of the box...</p>
         <div className="unixorn-example">
-          <Unixorn autoFocus />
+          <Unixorn {...config} />
         </div>
       </div>
 
+      <button onClick={() => setConfig({...config, prompt: ":("})}>Make above prompt sad</button>
+        
       <div className="example">
         <p>...But it's designed to be easy to customize.</p>
         <div id="custom-example" className="unixorn-example">
         </div>
-      </div>
+      bi</div>
     </div>
   );
 }

--- a/src/Unixorn.tsx
+++ b/src/Unixorn.tsx
@@ -29,6 +29,7 @@ const Unixorn: React.FunctionComponent<UnixornConfiguration> = props => {
       item: {
         type: VisualHistoryItemType.StartupOutput,
         content: msg || '',
+        prompt: props.prompt || defaultConfiguration.prompt,
       },
     });
   }, [props.startupMessage]);
@@ -82,6 +83,7 @@ const Unixorn: React.FunctionComponent<UnixornConfiguration> = props => {
             item: {
               type: VisualHistoryItemType.Error,
               content: `Unrecognized command: ${commandName}`,
+              prompt: props.prompt || defaultConfiguration.prompt,
             },
           });
         }
@@ -126,6 +128,7 @@ const Unixorn: React.FunctionComponent<UnixornConfiguration> = props => {
         item: {
           type: VisualHistoryItemType.Error,
           content: text,
+          prompt: props.prompt || defaultConfiguration.prompt,
         },
       });
     },
@@ -136,6 +139,7 @@ const Unixorn: React.FunctionComponent<UnixornConfiguration> = props => {
         item: {
           type: VisualHistoryItemType.Output,
           content: text,
+          prompt: props.prompt || defaultConfiguration.prompt,
         },
       });
     },
@@ -244,6 +248,7 @@ const Unixorn: React.FunctionComponent<UnixornConfiguration> = props => {
           item: {
             type: VisualHistoryItemType.Input,
             content: fullLine,
+            prompt: props.prompt || defaultConfiguration.prompt,
           },
         });
         const tokens = kernel.tokenize(fullLine);
@@ -286,7 +291,7 @@ const Unixorn: React.FunctionComponent<UnixornConfiguration> = props => {
                 <span
                   className={`${css(styles.text, styles.prompt)} unixorn-prompt`}
                 >
-                  {prompt}
+                  {item.prompt}
                 </span>
                 <span
                   className={`${css(styles.text, styles.textInput)} unixorn-input`}

--- a/src/reducers/history.ts
+++ b/src/reducers/history.ts
@@ -38,6 +38,7 @@ enum VisualHistoryItemType {
 interface VisualHistoryItem {
   type: VisualHistoryItemType;
   content: string;
+  prompt: string | undefined;
 }
 
 // Put most recent item at end of history.


### PR DESCRIPTION
right now, if you change the prompt, it will change all the previous input prompt prefix.

It cannot be utilised to provide `cd` implementation

This adds an extra field to visual history and keeps the previous prompt item intact while changing the future ones post the change .....

simple way to use it is added via an extra button in example, however, the implementation may vary from person to person